### PR TITLE
Add namespace specification for ingress and service in production ove…

### DIFF
--- a/k8s/overlays/prod/ingress-prod.yaml
+++ b/k8s/overlays/prod/ingress-prod.yaml
@@ -29,6 +29,7 @@ apiVersion: traefik.containo.us/v1alpha1
 kind: Middleware
 metadata:
   name: redirect-twitch
+  namespace: medal-bot
 spec:
   redirectRegex:
     regex: ^https://ikuro\.dev/?$
@@ -39,6 +40,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: noop-service
+  namespace: medal-bot
 spec:
   type: ExternalName
   externalName: twitch.tv


### PR DESCRIPTION
…rlay

This commit introduces the 'medal-bot' namespace to both the redirect middleware and the noop service in the production ingress configuration. This change enhances organization and clarity in the Kubernetes setup, ensuring that resources are correctly scoped within the intended namespace.